### PR TITLE
Activity Tracker Implementation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,15 +2,18 @@
     package="com.flutterflow.apfp"
     xmlns:tools="http://schemas.android.com/tools">
    <uses-permission android:name="android.permission.INTERNET"/>
+   <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
 
    <application
         android:label="myAPFP"
         tools:replace="android:label"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true">
+        
 
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,16 +41,10 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSCameraUsageDescription</key>
-	<string>Used to attach photos to your workouts</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>We will sync your data with the Apple Health app to give you better insights</string>
+		<string>We will sync your data with the Apple Health app to give you better insights</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>We will sync your data with the Apple Health app to give you better insights</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Used to record audio that can be attached to your workouts</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Used to attach images from camera roll to your workouts</string>
+		<string>We will sync your data with the Apple Health app to give you better insights</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -68,6 +62,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Used to attach photos to your workouts</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to attach images from camera roll to your workouts</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Used to record audio that can be attached to your workouts</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,6 +41,10 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSHealthShareUsageDescription</key>
+		<string>We will sync your data with the Apple Health app to give you better insights</string>
+	<key>NSHealthUpdateUsageDescription</key>
+		<string>We will sync your data with the Apple Health app to give you better insights</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,10 +41,16 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Used to attach photos to your workouts</string>
 	<key>NSHealthShareUsageDescription</key>
-		<string>We will sync your data with the Apple Health app to give you better insights</string>
+	<string>We will sync your data with the Apple Health app to give you better insights</string>
 	<key>NSHealthUpdateUsageDescription</key>
-		<string>We will sync your data with the Apple Health app to give you better insights</string>
+	<string>We will sync your data with the Apple Health app to give you better insights</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Used to record audio that can be attached to your workouts</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to attach images from camera roll to your workouts</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -62,12 +68,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>Used to attach photos to your workouts</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Used to attach images from camera roll to your workouts</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Used to record audio that can be attached to your workouts</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+</dict>
 </plist>

--- a/lib/widgets/activity/activity_widget.dart
+++ b/lib/widgets/activity/activity_widget.dart
@@ -1,8 +1,10 @@
 import 'package:apfp/firebase/firestore.dart';
+import 'package:apfp/util/toasted/toasted.dart';
 import 'package:apfp/util/validator/validator.dart';
 import 'package:apfp/widgets/confimation_dialog/confirmation_dialog.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:focused_menu/modals.dart';
+import 'package:health/health.dart';
 import 'package:intl/intl.dart';
 import 'package:share_plus/share_plus.dart';
 import '../add_activity/add_activity_widget.dart';
@@ -37,7 +39,25 @@ class _ActivityWidgetState extends State<ActivityWidget> {
     _collectActivity();
   }
 
-  void _collectActivity() {
+  void _collectActivity() async {
+    HealthFactory health = new HealthFactory();
+    List<HealthDataType> types = List.empty(growable: true);
+    types.addAll([HealthDataType.WORKOUT]);
+    await health.requestAuthorization(types).then((value) async {
+      if (value) {
+        DateTime now = DateTime.now();
+        await health
+            .getHealthDataFromTypes(
+                DateTime(now.year, now.month, now.day), now, types)
+            .then((value) {
+          for (HealthDataPoint dataPoint in value) {
+            print(dataPoint);
+          }
+        });
+      } else {
+        Toasted.showToast("Permission to collect health data denied.");
+      }
+    });
     widget.activityStream.forEach((element) {
       Map sortedMap = new Map();
       if (element.data() == null) {
@@ -280,7 +300,6 @@ class _ActivityWidgetState extends State<ActivityWidget> {
                 ),
               ),
             ],
-
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   share_plus: ^3.0.4
   image_picker: ^0.8.4+6
   animated_text_kit: ^4.2.1
+  health: ^3.4.3
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   image_picker: ^0.8.4+6
   animated_text_kit: ^4.2.1
   health: ^3.4.3
+  permission_handler: ^8.3.0
 
 
 dev_dependencies:


### PR DESCRIPTION
PLEASE DON'T MERGE YET, CALEB IS STILL WORKING ON THIS.

This pull request introduces rudimentary activity data collection from the Apple Health and Google Fit apps. This activity data is automatically logged in the application as activity cards, and this information is also uploaded to the Firestore database. 

At this time, Android activity cards are based on move minutes. This means that, in any given day, on an Android device, only one activity will be logged, with the total number of move minutes from all activities logged in Google Fit for the day. For iOS, each workout will be logged, with its duration. Workouts are not supported on Android. All imported workouts are titled "Imported Workout" and typed "Exercise," but the duration and time logged are both accurate. 

A user must be authorized as a developer in the Google Cloud Platform console to grant access to collect Google Fit data. Once the app is verified and published, anyone with a Google account will be able to grant access.

To test, log some activity in either the Google Fit or Apple Health app, then open myAPFP. It is recommended to do a flutter clean as well as a fresh install to the device, as permissions prompts are very picky about when they are presented. Activity should be automatically logged upon reaching the Home page. Data is currently only updated when the app is cleared from memory and relaunched, but this is just a start, which is what we promised for this sprint.