### PR TITLE
Bug fixes regarding exercise videos and home page announcements

### DIFF
--- a/lib/firebase/firestore.dart
+++ b/lib/firebase/firestore.dart
@@ -9,10 +9,7 @@ class FireStore {
   }
 
   static Stream<QuerySnapshot> getYTVideoUrls() {
-    return FirebaseFirestore.instance
-        .collection('youtube-videos')
-        .orderBy("id", descending: true)
-        .snapshots();
+    return FirebaseFirestore.instance.collection('youtube-videos').snapshots();
   }
 
   static void storeUID(String docId, String uid) {
@@ -113,7 +110,7 @@ class FireStore {
       "exerciseTimeEndGoal": 0,
       "exerciseTimeEndGoal_w": 0,
       "calGoalProgress": 0,
-      "calGoalProgressWeekly" : 0,
+      "calGoalProgressWeekly": 0,
       "calEndGoal": 0,
       "calEndGoal_w": 0,
       "stepGoalProgress": 0,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -148,13 +148,13 @@ class _NavBarPageState extends State<NavBarPage> with WidgetsBindingObserver {
     return _updateConnectionStatus(result);
   }
 
-   Future<void> _updateConnectionStatus(ConnectivityResult result) async {
+  Future<void> _updateConnectionStatus(ConnectivityResult result) async {
     _connectionStatus = result;
     if (_isInForeground) {
       if (_connectionStatus == ConnectivityResult.none) {
         _internetConnected = false;
         showSnackbar(context, "Please check your Internet connection",
-          duration: Duration(days: 365), noConnection: true);
+            duration: Duration(days: 365), noConnection: true);
       } else if (_connectionStatus == ConnectivityResult.wifi ||
           _connectionStatus == ConnectivityResult.mobile) {
         if (!_internetConnected) {

--- a/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
+++ b/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
@@ -196,7 +196,7 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
   }
 
   void preloadAllVideos() async {
-    await (Internet.isConnected()).then((value) => {
+    await (Internet.isConnected()).then((value) async => {
           if (value)
             {
               setState(() {
@@ -205,7 +205,7 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
               })
             }
           else
-            {preloadAllVideos()}
+            {Timer(Duration(milliseconds: 25), preloadAllVideos)}
         });
     _isVideosLoaded = true;
   }

--- a/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
+++ b/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
@@ -110,8 +110,8 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
                         mainAxisSize: MainAxisSize.max,
                         children: [
                           SizedBox(
-                              width: MediaQuery.of(context).size.width * 0.1),
-                          Text("$_index", style: FlutterFlowTheme.title3),
+                              width: MediaQuery.of(context).size.width * 0.12),
+                          Icon(Icons.live_tv),
                         ],
                       ),
                       Column(

--- a/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
+++ b/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
+import '../../util/internet_connection/internet.dart';
 import '../confimation_dialog/confirmation_dialog.dart';
 import '../exercise_video/exercise_video_widget.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
@@ -28,8 +29,8 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
   bool _isVideosLoaded = false;
   List<String> playlistIDs = [];
   List<String> videoURLs = [];
-  List<String> playlistBackup = [];
-  List<String> videoBackup = [];
+  List<Widget> playlistBackup = [];
+  List<Widget> videoBackup = [];
 
   @override
   void initState() {
@@ -194,45 +195,50 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
     ]);
   }
 
-  void preloadAllVideos() {
-    _preloadPlaylists();
-    _preloadVideos();
+  void preloadAllVideos() async {
+    await (Internet.isConnected()).then((value) => {
+          if (value)
+            {
+              setState(() {
+                _populateVideos();
+                _populatePlaylists();
+              })
+            }
+          else
+            {preloadAllVideos()}
+        });
     _isVideosLoaded = true;
   }
 
-  void _preloadPlaylists() {
-    widget.playlistStream.forEach(((snapshot) {
-      _index = 0;
-      snapshot.docs.forEach((document) {
-        playlistIDs.add(document["id"]);
-      });
-      playlistBackup = playlistIDs.toList();
-      _updateVideoList();
-      playlistIDs.clear();
-    }));
-  }
-
-  void _updateVideoList() {
-    videoList.clear();
-    if (playlistBackup.isNotEmpty && videoBackup.isNotEmpty) {
-      for (String id in playlistBackup) {
-        _preloadPlaylist(id);
-      }
-      for (String url in videoBackup) {
-        _preloadVideo(url);
-      }
-    }
-  }
-
-  void _preloadVideos() {
+  void _populateVideos() {
     widget.videoStream.forEach((snapshot) {
-      _index = 0;
-      snapshot.docs.forEach((document) {
-        videoURLs.add(document["url"]);
+      setState(() {
+        for (Widget element in videoBackup) {
+          if (videoList.contains(element)) {
+            videoList.remove(element);
+          }
+        }
+        videoBackup.clear();
       });
-      videoBackup = videoURLs.toList();
-      _updateVideoList();
-      videoURLs.clear();
+      snapshot.docs.forEach((document) {
+        _preloadVideo(document["url"]);
+      });
+    });
+  }
+
+  void _populatePlaylists() {
+    widget.playlistStream.forEach((snapshot) {
+      setState(() {
+        for (Widget element in playlistBackup) {
+          if (videoList.contains(element)) {
+            videoList.remove(element);
+          }
+        }
+        playlistBackup.clear();
+      });
+      snapshot.docs.forEach((document) {
+        _preloadPlaylist(document["id"]);
+      });
     });
   }
 
@@ -240,12 +246,14 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
     YoutubeExplode yt = YoutubeExplode();
     Video video = await yt.videos.get(url);
     _index++;
-    _addVideoToList(_videoTrainingCard(
+    Padding videoCard = _videoTrainingCard(
         index: _index,
         author: video.author,
         url: video.url,
         title: video.title,
-        video: video));
+        video: video);
+    _addVideoToList(videoCard);
+    videoBackup.add(videoCard);
     yt.close();
   }
 
@@ -254,12 +262,14 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
     Playlist playlist = await yt.playlists.get(id);
     await for (Video video in yt.playlists.getVideos(playlist.id)) {
       _index++;
-      _addVideoToList(_videoTrainingCard(
+      Padding videoCard = _videoTrainingCard(
           index: _index,
           author: video.author,
           url: video.url,
           title: video.title,
-          video: video));
+          video: video);
+      _addVideoToList(videoCard);
+      playlistBackup.add(videoCard);
     }
     yt.close();
   }

--- a/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
+++ b/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
@@ -205,7 +205,7 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
               })
             }
           else
-            {Timer(Duration(milliseconds: 25), preloadAllVideos)}
+            {Timer(Duration(milliseconds: 200), preloadAllVideos)}
         });
     _isVideosLoaded = true;
   }

--- a/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
+++ b/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
@@ -205,7 +205,7 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
               })
             }
           else
-            {Timer(Duration(milliseconds: 200), preloadAllVideos)}
+            {Timer(Duration(seconds: 1), preloadAllVideos)}
         });
     _isVideosLoaded = true;
   }

--- a/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
+++ b/lib/widgets/at_home_exercises/at_home_exercises_widget.dart
@@ -110,8 +110,8 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
                         mainAxisSize: MainAxisSize.max,
                         children: [
                           SizedBox(
-                              width: MediaQuery.of(context).size.width * 0.12),
-                          Icon(Icons.live_tv),
+                              width: MediaQuery.of(context).size.width * 0.07),
+                          // Icon(Icons.live_tv),
                         ],
                       ),
                       Column(
@@ -138,7 +138,7 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
     return Row(children: [
       Container(
           constraints: BoxConstraints(
-              maxWidth: MediaQuery.of(context).size.width * 0.75),
+              maxWidth: MediaQuery.of(context).size.width * 0.85),
           child: AutoSizeText(
             title,
             maxLines: 1,
@@ -153,7 +153,7 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
     return Row(children: [
       Container(
         constraints:
-            BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.75),
+            BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.85),
         child: AutoSizeText.rich(
           TextSpan(
               text: 'Source: ',
@@ -173,7 +173,7 @@ class _AtHomeExercisesWidgetState extends State<AtHomeExercisesWidget> {
     return Row(children: [
       Container(
           constraints: BoxConstraints(
-              maxWidth: MediaQuery.of(context).size.width * 0.75),
+              maxWidth: MediaQuery.of(context).size.width * 0.85),
           child: AutoSizeText.rich(
             TextSpan(
                 text: 'Video Length: ',

--- a/lib/widgets/home/home_widget.dart
+++ b/lib/widgets/home/home_widget.dart
@@ -689,10 +689,19 @@ class _HomeWidgetState extends State<HomeWidget> {
                       AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>>
                           snapshot) {
                     if (snapshot.hasData) {
+                      List<String> alertTexts =
+                          new List.filled(3, "No older announcements.");
+                      if (snapshot.data!.docs.length > 0) {
+                        alertTexts[0] = snapshot.data?.docs[0]['title'];
+                      }
+                      if (snapshot.data!.docs.length > 1) {
+                        alertTexts[1] = snapshot.data?.docs[1]['title'];
+                      }
+                      if (snapshot.data!.docs.length > 2) {
+                        alertTexts[2] = snapshot.data?.docs[2]['title'];
+                      }
                       return _announcements(
-                          snapshot.data?.docs[0]['title'],
-                          snapshot.data?.docs[1]['title'],
-                          snapshot.data?.docs[2]['title']);
+                          alertTexts[0], alertTexts[1], alertTexts[2]);
                     } else {
                       return Text("No announcements available.");
                     }


### PR DESCRIPTION
This branch resolves some bugs that were introduced while implementing features in the application.

- YouTube videos and playlists are now dynamically updated independent from one another, rather than refreshing the entire list whenever one of the two collections is changed.
- The index numbers have been removed from the exercise video cards.
- Resolved bug: when opening the app in a logged in state without an internet connection, upon reconnection, the videos now populate automatically. This is implemented by checking internet connection and recursively attempting to preload the videos at a fixed duration until internet connection has been restored.
- Resolved bug: when either the playlists or videos collection is empty, the entries from the other collection still load. They operate independently and both need not be populated in order for the videos to be displayed.
- Resolved bug: the three most recent announcement titles broke the home page if there were fewer than 3 announcements in the database. This has been resolved.