### PR TITLE
Add basal calories import on iOS devices

### DIFF
--- a/lib/widgets/activity/activity_widget.dart
+++ b/lib/widgets/activity/activity_widget.dart
@@ -61,7 +61,8 @@ class _ActivityWidgetState extends State<ActivityWidget> {
       HealthDataType.WORKOUT,
       HealthDataType.STEPS,
       HealthDataType.DISTANCE_WALKING_RUNNING,
-      HealthDataType.ACTIVE_ENERGY_BURNED
+      HealthDataType.ACTIVE_ENERGY_BURNED,
+      HealthDataType.BASAL_ENERGY_BURNED
     ]).then((value) async {
       if (value) {
         DateTime now = DateTime.now();

--- a/lib/widgets/home/home_widget.dart
+++ b/lib/widgets/home/home_widget.dart
@@ -242,9 +242,12 @@ class _HomeWidgetState extends State<HomeWidget> {
           _isFetchingHealthData = true;
         });
         try {
-          var calData = await health.getHealthDataFromTypes(midnight, now, [
-            HealthDataType.ACTIVE_ENERGY_BURNED // Calories
-          ]);
+          List<HealthDataType> calorieTypes = List.empty(growable: true);
+          if (Platform.isIOS)
+            calorieTypes.add(HealthDataType.BASAL_ENERGY_BURNED);
+          calorieTypes.add(HealthDataType.ACTIVE_ENERGY_BURNED);
+          var calData =
+              await health.getHealthDataFromTypes(midnight, now, calorieTypes);
           var calSet = calData.toSet();
           cals = HealthUtil.getHealthSums(calSet);
           var mileData = await health.getHealthDataFromTypes(midnight, now, [


### PR DESCRIPTION
This pull request matches calorie import behavior between Android and iOS devices. All energy (active and basal) is imported via the single HealthDataType ACTIVE_ENERGY_BURNED on Android, but only active energy is pulled from that data type on iOS. This branch imports the BASAL_ENERGY_BURNED data type on iOS to ensure matching behavior among the platforms.